### PR TITLE
Fix test runner generation with test name that is substring of another test name

### DIFF
--- a/example/uut_and_tests/tests_src/test_foo_bar.c
+++ b/example/uut_and_tests/tests_src/test_foo_bar.c
@@ -1,0 +1,16 @@
+
+#include <unity.h>
+#include "uut.h"
+
+
+void setUp(){}
+void tearDown(){}
+
+void test_foo_bar0(void) {
+    TEST_ASSERT_EQUAL(1, uut_returns_1());
+}
+
+void test_foo_bar1(void) {
+    TEST_ASSERT_EQUAL(1, uut_returns_1());
+}
+

--- a/lib_unity/lib_build_info.cmake
+++ b/lib_unity/lib_build_info.cmake
@@ -45,7 +45,7 @@ if(LIB_UNITY_AUTO_TEST_RUNNER)
         endif()
 
         set(this_target ${APP_BUILD_TARGETS})
-        list(FILTER this_target INCLUDE REGEX ".*_${config_suffix}")
+        list(FILTER this_target INCLUDE REGEX ".*_${config_suffix}$$")
 
         set(TEST_RUNNER ${CMAKE_CURRENT_BINARY_DIR}/${config_suffix}_runner.c)
         add_custom_command(


### PR DESCRIPTION
- Added `test_foo_bar` to the uut_and_tests example: the existing code fails because the suffix regex for test_foo matches both test_foo and test_foo_bar
- Fixed the regex by matching the test name to the end of the string