### PR TITLE
Test targets now inherit compiler flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 build/
 bin/
 
+.venv*/

--- a/example/uut_and_tests/CMakeLists.txt
+++ b/example/uut_and_tests/CMakeLists.txt
@@ -11,11 +11,17 @@ set(APP_DEPENDENT_MODULES lib_unity)
 file(GLOB APP_C_SRCS CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_LIST_DIR} uut_src/* tests_src/*)
 set(APP_INCLUDES uut_src)
 
+set(COMPILER_FLAGS      -g
+                        -report
+                        -Wall 
+                        -Wextra)
+
 # Create config for each test
 file(GLOB tests RELATIVE ${CMAKE_CURRENT_LIST_DIR} CONFIGURE_DEPENDS tests_src/test*.c)
 foreach(test_file ${tests})
     get_filename_component(test_name ${test_file} NAME_WE)
-    set(SOURCE_FILES_${test_name} ${test_file})
+    set(SOURCE_FILES_${test_name}       ${test_file})
+    set(APP_COMPILER_FLAGS_${test_name} ${COMPILER_FLAGS})
 endforeach()
 
 # Enable auto gen of test runners


### PR DESCRIPTION
When creating cusomt targets, one per test file, the compiler flags are not commonly passed in correctly.